### PR TITLE
Fix tags type in post template

### DIFF
--- a/src/templates/postTemplate.tsx
+++ b/src/templates/postTemplate.tsx
@@ -10,7 +10,7 @@ type DataProps = {
         title: string,
         path: string,
         date: string,
-        tags: [string]
+        tags: string[]
       },
       html: string
     }


### PR DESCRIPTION
## Summary
- fix tags TypeScript type array

## Testing
- `npm test` *(fails: Write tests! -> https://gatsby.dev/unit-testing)*

------
https://chatgpt.com/codex/tasks/task_b_683a067a0f448327b9a4d6a0e6bc3636